### PR TITLE
Feature/rand wupdate

### DIFF
--- a/machine_data_model/data_model.py
+++ b/machine_data_model/data_model.py
@@ -195,7 +195,7 @@ class DataModel:
         """
         node = self.get_node(variable_id)
         if isinstance(node, VariableNode):
-            node.update(value)
+            node.write(value)
             return True
         raise ValueError(f"Variable '{variable_id}' not found in data model")
 

--- a/machine_data_model/nodes/composite_method/control_flow_scope.py
+++ b/machine_data_model/nodes/composite_method/control_flow_scope.py
@@ -65,7 +65,7 @@ class ControlFlowScope:
 
     def set_pc(self, pc: int) -> None:
         """
-        Update the program counter of the scope.
+        Write the program counter of the scope.
 
         :param pc: The new program counter of the scope.
         """

--- a/machine_data_model/nodes/composite_method/write_variable_node.py
+++ b/machine_data_model/nodes/composite_method/write_variable_node.py
@@ -42,5 +42,5 @@ class WriteVariableNode(ControlFlowNode):
         """
         assert isinstance(self._ref_node, VariableNode)
         value = resolve_value(self._value, scope)
-        self._ref_node.update(value)
+        self._ref_node.write(value)
         return True

--- a/machine_data_model/protocols/glacier_v1/glacier_protocol_mng.py
+++ b/machine_data_model/protocols/glacier_v1/glacier_protocol_mng.py
@@ -322,7 +322,7 @@ class GlacierProtocolMng(ProtocolMng):
             msg.payload.value = value
             return _create_response_msg(msg)
         if msg.header.msg_name == VariableMsgName.WRITE:
-            if variable_node.update(msg.payload.value):
+            if variable_node.write(msg.payload.value):
                 return _create_response_msg(msg)
             return _create_response_msg(msg, _error_not_allowed)
         if msg.header.msg_name == VariableMsgName.SUBSCRIBE:

--- a/tests/nodes/test_variable_node.py
+++ b/tests/nodes/test_variable_node.py
@@ -37,10 +37,10 @@ class TestVariableNode:
 
         assert str_var.name == var_name
         assert str_var.description == var_description
-        assert str_var.read() == var_value
+        assert str_var.value == var_value
 
     @pytest.mark.parametrize("var_value", [gen_random_string(10) for _ in range(3)])
-    def test_string_variable_node_update(
+    def test_string_variable_node_write(
         self, var_name: str, var_description: str, var_value: str
     ) -> None:
         str_var = StringVariableNode(
@@ -48,11 +48,11 @@ class TestVariableNode:
         )
 
         new_value = gen_random_string(10)
-        str_var.update(new_value)
+        str_var.value = new_value
 
         assert str_var.name == var_name
         assert str_var.description == var_description
-        assert str_var.read() == new_value
+        assert str_var.value == new_value
 
     def test_boolean_variable_node_creation(
         self, var_name: str, var_description: str
@@ -63,20 +63,20 @@ class TestVariableNode:
 
         assert bool_var.name == var_name
         assert bool_var.description == var_description
-        assert bool_var.read()
+        assert bool_var.value
 
-    def test_boolean_variable_node_update(
+    def test_boolean_variable_node_write(
         self, var_name: str, var_description: str
     ) -> None:
         bool_var = BooleanVariableNode(
             name=var_name, description=var_description, value=True
         )
 
-        bool_var.update(False)
+        bool_var.value = False
 
         assert bool_var.name == var_name
         assert bool_var.description == var_description
-        assert not bool_var.read()
+        assert not bool_var.value
 
     @pytest.mark.parametrize(
         "var_value", [random.uniform(0, 1000) for i in range(NUM_TESTS)]
@@ -102,7 +102,7 @@ class TestVariableNode:
 
         assert numeric_var.name == var_name
         assert numeric_var.description == var_description
-        assert numeric_var.read() == var_value
+        assert numeric_var.value == var_value
 
     @pytest.mark.parametrize(
         "var_value", [random.uniform(0, 1000) for i in range(NUM_TESTS)]
@@ -116,18 +116,18 @@ class TestVariableNode:
             "NoneMeasureUnits.NONE",
         ],
     )
-    def test_numeric_variable_node_update(
+    def test_numeric_variable_node_write(
         self, var_name: str, var_description: str, var_value: float, unit: Enum | str
     ) -> None:
         numeric_var = NumericalVariableNode(
             name=var_name, description=var_description, value=-1, measure_unit=unit
         )
 
-        numeric_var.update(var_value)
+        numeric_var.value = var_value
 
         assert numeric_var.name == var_name
         assert numeric_var.description == var_description
-        assert numeric_var.read() == var_value
+        assert numeric_var.value == var_value
 
     def test_object_variable_node_creation(
         self, var_name: str, var_description: str
@@ -144,8 +144,8 @@ class TestVariableNode:
             assert obj_var.get_property(key) == properties[key]
         prop_val = {}
         for key in properties:
-            prop_val[key] = properties[key].read()
-        assert obj_var.read() == prop_val
+            prop_val[key] = properties[key].value
+        assert obj_var.value == prop_val
 
     def test_object_variable_node_update(
         self, var_name: str, var_description: str

--- a/tests/protocols/glacier_v1/test_message_mng.py
+++ b/tests/protocols/glacier_v1/test_message_mng.py
@@ -211,7 +211,7 @@ class TestGlacierProtocolMng:
         assert not manager.get_update_messages()
 
         # update the waiting variable
-        wait_node.update(30)
+        wait_node.write(30)
 
         assert manager.get_update_messages()
 

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -139,7 +139,7 @@ class TestDataModel:
         child.set_subscription_callback(update_message_callback)
         # Perform an update on the child node, triggering the deferred notify
         # mechanism.
-        child.update("Perfect!")
+        child.write("Perfect!")
         # Assert that the child node has subscribers.
         assert child.has_subscribers()
         # Assert that the changes list contains the expected value.


### PR DESCRIPTION
Since we access variable values through "read", I changed the "update" method to "write". "Write" is more appropriate for this operation, and since in the glacier project we use the keyword "WRITE", it could confuse new users.
The significant change refers to the value property in VariableNode, where we can now access node values directly.
I.e.:
mynode.read() -> mynode.value
mynode.write(something) -> mynode.value = something

The functionality is the same as before, but it's hidden by ".value".