### PR TITLE
fix: associate ControlFlow with CompositeMethodNode in examples and tests

### DIFF
--- a/examples/tracing/control_flow_tracing.py
+++ b/examples/tracing/control_flow_tracing.py
@@ -9,6 +9,9 @@ and program counter positions.
 import time
 from machine_data_model.data_model import DataModel
 from machine_data_model.nodes.variable_node import NumericalVariableNode
+from machine_data_model.nodes.composite_method.composite_method_node import (
+    CompositeMethodNode,
+)
 from machine_data_model.behavior.local_execution_node import (
     ReadVariableNode,
     WriteVariableNode,
@@ -36,11 +39,24 @@ def main() -> None:
     data_model = DataModel(name="ControlFlowTracingExample")
 
     # Add variables for the control flow operations
-    counter_var = NumericalVariableNode(id="counter", name="counter", value=0)
-    result_var = NumericalVariableNode(id="result", name="result", value=0.0)
+    counter_var = NumericalVariableNode(
+        id="counter",
+        name="counter",
+        value=0,
+    )
+    result_var = NumericalVariableNode(
+        id="result",
+        name="result",
+        value=0.0,
+    )
+    composite_method = CompositeMethodNode(
+        id="control_flow_method",
+        name="Control Flow Method",
+    )
     # Add variables to the root node.
     data_model.root.add_child(counter_var)
     data_model.root.add_child(result_var)
+    data_model.root.add_child(composite_method)
 
     # Register nodes.
     data_model._register_nodes(data_model.root)
@@ -59,7 +75,14 @@ def main() -> None:
     increment_counter.set_ref_node(counter_var)
 
     # Create the control flow graph
-    control_flow = ControlFlow([read_counter, write_result, increment_counter])
+    control_flow = ControlFlow(
+        [
+            read_counter,
+            write_result,
+            increment_counter,
+        ],
+        composite_method_node=composite_method,
+    )
 
     # Simulate control flow execution multiple times
     print("Simulating control flow execution...")

--- a/examples/tracing/mixed_execution_tracing.py
+++ b/examples/tracing/mixed_execution_tracing.py
@@ -9,6 +9,9 @@ import atexit
 from typing import Dict, Any
 from machine_data_model.data_model import DataModel
 from machine_data_model.nodes.variable_node import NumericalVariableNode
+from machine_data_model.nodes.composite_method.composite_method_node import (
+    CompositeMethodNode,
+)
 from machine_data_model.behavior.local_execution_node import WriteVariableNode
 from machine_data_model.behavior.remote_execution_node import ReadRemoteVariableNode
 from machine_data_model.behavior.control_flow import ControlFlow
@@ -207,7 +210,12 @@ def local_machine_process(
             name="local_temp",
             value=INIT_TEMP,
         )
+        composite_method = CompositeMethodNode(
+            id="temp_sync_method",
+            name="Temperature Sync Method",
+        )
         local_machine.root.add_child(local_temp)
+        local_machine.root.add_child(composite_method)
         local_machine._register_nodes(local_machine.root)
 
         machine_log(f"Initialized with temperature: {INIT_TEMP}")
@@ -229,7 +237,8 @@ def local_machine_process(
             [
                 read_remote_temp,
                 write_local_temp,
-            ]
+            ],
+            composite_method_node=composite_method,
         )
 
         # Execute: Phase 1 - Send request

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -5,13 +5,19 @@ import uuid
 from machine_data_model.data_model import DataModel
 from machine_data_model.nodes.variable_node import NumericalVariableNode, VariableNode
 from machine_data_model.nodes.method_node import MethodNode
+from machine_data_model.nodes.composite_method.composite_method_node import (
+    CompositeMethodNode,
+)
 from machine_data_model.nodes.subscription.variable_subscription import (
     VariableSubscription,
 )
 from machine_data_model.behavior.local_execution_node import (
+    ReadVariableNode,
+    WriteVariableNode,
     WaitConditionNode,
     WaitConditionOperator,
 )
+from machine_data_model.behavior.control_flow import ControlFlow
 from machine_data_model.behavior.execution_context import ExecutionContext
 from machine_data_model.tracing import (
     get_global_collector,
@@ -368,14 +374,14 @@ class TestDataModelTracing:
         data_model.root.add_child(var)
         data_model._register_nodes(data_model.root)
 
-        # Create control flow nodes
-        from machine_data_model.behavior.local_execution_node import (
-            ReadVariableNode,
-            WriteVariableNode,
+        # Create a composite method node for the control flow
+        composite_method = CompositeMethodNode(
+            id="test_control_flow_method", name="Test Control Flow Method"
         )
-        from machine_data_model.behavior.control_flow import ControlFlow
-        from machine_data_model.behavior.execution_context import ExecutionContext
+        data_model.root.add_child(composite_method)
+        data_model._register_nodes(data_model.root)
 
+        # Create control flow nodes
         read_node = ReadVariableNode(variable_node="test_var", store_as="read_value")
         read_node.set_ref_node(var)
 
@@ -383,7 +389,9 @@ class TestDataModelTracing:
         write_node.set_ref_node(var)
 
         # Create control flow with the nodes
-        control_flow = ControlFlow([read_node, write_node])
+        control_flow = ControlFlow(
+            [read_node, write_node], composite_method_node=composite_method
+        )
 
         # Create context and execute
         context = ExecutionContext("test_context")


### PR DESCRIPTION
- Update control_flow_tracing.py to link ControlFlow with CompositeMethodNode
- Update mixed_execution_tracing.py to link ControlFlow with CompositeMethodNode
- Update test_tracing.py to link ControlFlow with CompositeMethodNode for consistency