### PR TITLE
feature(composite-method): implement internal nodes for composite methods

### DIFF
--- a/machine_data_model/data_model.py
+++ b/machine_data_model/data_model.py
@@ -155,20 +155,20 @@ class DataModel:
         if not isinstance(node, CompositeMethodNode):
             return
 
+        resolver = node.get_node_resolver()
+
         for cf_node in node.cfg.nodes():
             if isinstance(cf_node, RemoteExecutionNode):
                 cf_node.sender_id = self._name
-                continue
-
-            assert isinstance(cf_node, LocalExecutionNode)
-
-            if cf_node.is_node_static():
-                ref_node = self.get_node(cf_node.node)
-                assert isinstance(ref_node, DataModelNode)
-                cf_node.set_ref_node(ref_node)
+            elif isinstance(cf_node, LocalExecutionNode):
+                if cf_node.is_node_static():
+                    ref_node = resolver(cf_node.node)
+                    assert isinstance(ref_node, DataModelNode)
+                    cf_node.set_ref_node(ref_node)
+                else:
+                    cf_node.get_data_model_node = resolver
             else:
-                # set get_node function to resolve the node at runtime
-                cf_node.get_data_model_node = self.get_node
+                raise ValueError(f"Unknown node type: {type(cf_node)}")
 
     def _register_nodes(self, node: FolderNode | ObjectVariableNode) -> None:
         """

--- a/machine_data_model/nodes/variable_node.py
+++ b/machine_data_model/nodes/variable_node.py
@@ -1040,3 +1040,18 @@ class ObjectVariableNode(VariableNode):
 
         """
         return self.__str__()
+
+
+class InternalVariableNode(VariableNode):
+    """
+    A marker class for variable nodes that are internal to a composite method.
+
+    Internal variable nodes are not accessible from external clients and are
+    only accessible within the control flow of the composite method that
+    contains them.
+
+    This class doesn't add any functionality beyond the base VariableNode,
+    but serves as a marker for internal use.
+    """
+
+    pass

--- a/tests/nodes/composite_method/test_composite_method.py
+++ b/tests/nodes/composite_method/test_composite_method.py
@@ -330,7 +330,7 @@ class TestCompositeMethod:
         assert method.is_terminated(context)
 
 
-def test_internal_nodes():
+def test_internal_nodes() -> None:
     """Test that internal nodes are accessible within composite methods but not externally."""
     from machine_data_model.nodes.folder_node import FolderNode
     from machine_data_model.nodes.variable_node import BooleanVariableNode

--- a/tests/nodes/composite_method/test_composite_method.py
+++ b/tests/nodes/composite_method/test_composite_method.py
@@ -8,6 +8,7 @@ from machine_data_model.behavior.control_flow import ControlFlow
 from machine_data_model.behavior.local_execution_node import (
     WaitConditionNode,
 )
+from machine_data_model.data_model import DataModel
 from machine_data_model.nodes.composite_method.composite_method_node import (
     CompositeMethodNode,
 )
@@ -327,3 +328,55 @@ class TestCompositeMethod:
         result = method.resume_execution(context)
         assert not result.messages
         assert method.is_terminated(context)
+
+
+def test_internal_nodes():
+    """Test that internal nodes are accessible within composite methods but not externally."""
+    from machine_data_model.nodes.folder_node import FolderNode
+    from machine_data_model.nodes.variable_node import BooleanVariableNode
+
+    # Create a data model with a root folder
+    root = FolderNode(name="root", description="Root folder")
+    data_model = DataModel(name="test_dm", root=root)
+
+    # Add a regular variable to the data model
+    regular_var = BooleanVariableNode(
+        id="regular_var", name="regular_var", description="Regular variable", value=True
+    )
+    root.add_child(regular_var)
+    data_model._register_node(regular_var)
+
+    # Create a composite method
+    composite_method = CompositeMethodNode(
+        id="test_composite",
+        name="Test Composite",
+        description="Test composite method with internal nodes",
+    )
+    root.add_child(composite_method)
+    data_model._register_node(composite_method)
+
+    # Create an internal variable node
+    internal_var = BooleanVariableNode(
+        id="internal_var",
+        name="internal_var",
+        description="Internal variable",
+        value=False,
+    )
+
+    # Add the internal node to the composite method
+    composite_method.add_internal_node(internal_var)
+
+    # Verify that the regular variable is accessible via data model
+    assert data_model.get_node("regular_var") is regular_var
+
+    # Verify that the internal node is not accessible via data model
+    assert data_model.get_node("internal_var") is None
+
+    # But it should be accessible via the composite method's resolver
+    resolver = composite_method.get_node_resolver()
+    resolved_node = resolver("internal_var")
+    assert resolved_node is internal_var
+
+    # And the resolver should still find regular nodes
+    resolved_regular = resolver("regular_var")
+    assert resolved_regular is regular_var


### PR DESCRIPTION
- Add internal nodes registry to CompositeMethodNode
- Implement custom node resolver for control flow isolation
- Create InternalVariableNode marker class
- Update data model to use custom resolver for composite methods
- Add comprehensive tests for internal node functionality

This addresses the issue where external messages could interfere with composite method wait conditions by providing isolated internal variables.