### PR TITLE
feature(subscription): scope wait callbacks at runtime

### DIFF
--- a/examples/subscription/README.md
+++ b/examples/subscription/README.md
@@ -9,6 +9,14 @@ This folder contains examples demonstrating the subscription mechanism in `Varia
 
 ## Examples
 
+### 0. Scoped Subscription (`scoped_subscription.py`)
+
+Demonstrates a small hierarchical data model and then attaches multiple
+callbacks directly to subscription objects at runtime, without configuring a
+node-level callback.
+
+Run: `python examples/subscription/scoped_subscription.py`
+
 ### 1. Basic Subscription (`basic_subscription.py`)
 
 Demonstrates subscribing to a `NumericalVariableNode`, setting a callback, and receiving notifications on value updates.

--- a/examples/subscription/scoped_subscription.py
+++ b/examples/subscription/scoped_subscription.py
@@ -1,0 +1,97 @@
+"""Example: Multiple scoped subscription callbacks inside a small data model.
+
+This demonstrates a small hierarchical data model, then attaches a subscription
+callback directly to the subscription object at runtime.
+"""
+
+from typing import Any
+
+from machine_data_model.data_model import DataModel
+from machine_data_model.nodes.folder_node import FolderNode
+from machine_data_model.nodes.subscription.variable_subscription import (
+    VariableSubscription,
+)
+from machine_data_model.nodes.variable_node import (
+    NumericalVariableNode,
+    VariableNode,
+)
+
+
+def print_model(folder: FolderNode, indent: int = 0) -> None:
+    """Print a folder tree with current variable values."""
+    prefix = " " * indent
+    print(f"{prefix}- {folder.name}")
+    for child in folder:
+        if isinstance(child, FolderNode):
+            print_model(child, indent + 2)
+        elif isinstance(child, NumericalVariableNode):
+            print(f"{prefix}  - {child.name} = {child.read()}")
+        else:
+            print(f"{prefix}  - {child.name} ({type(child).__name__})")
+
+
+def subscription_callback(
+    subscription: VariableSubscription,
+    node: VariableNode,
+    value: Any,
+) -> None:
+    """Print a notification when the subscription fires."""
+    print(f"  {subscription.subscriber_id} saw {node.name} -> {value}")
+
+
+def main() -> None:
+    """Run the scoped subscription example."""
+    data_model = DataModel(
+        name="SubscriptionExample",
+        description="Small model for demonstrating scoped subscriptions",
+    )
+
+    machine = FolderNode(name="machine", description="Demo machine")
+    sensors = FolderNode(name="sensors", description="Sensor values")
+    actuators = FolderNode(name="actuators", description="Actuator values")
+
+    temperature = NumericalVariableNode(name="temperature", value=20.0)
+    pressure = NumericalVariableNode(name="pressure", value=1.0)
+    fan_speed = NumericalVariableNode(name="fan_speed", value=1000.0)
+
+    sensors.add_child(temperature)
+    sensors.add_child(pressure)
+    actuators.add_child(fan_speed)
+    machine.add_child(sensors)
+    machine.add_child(actuators)
+    data_model.root.add_child(machine)
+
+    data_model._register_nodes(data_model.root)
+
+    print("Data model layout:")
+    print_model(data_model.root)
+
+    subscription_a = VariableSubscription(
+        subscriber_id="listener_1",
+        correlation_id="temperature_scope",
+        subscription_callback=subscription_callback,
+    )
+
+    subscription_b = VariableSubscription(
+        subscriber_id="listener_2",
+        correlation_id="temperature_scope_b",
+        subscription_callback=subscription_callback,
+    )
+
+    temperature_path = temperature.qualified_name
+    if data_model.subscribe(temperature_path, subscription_a):
+        print(f"Subscribed 1 listener at runtime to {temperature_path}")
+
+    pressure_path = pressure.qualified_name
+    if data_model.subscribe(pressure_path, subscription_b):
+        print(f"Subscribed 1 listener at runtime to {pressure_path}")
+
+    print("\nUpdating temperature to 25.0")
+    data_model.write_variable(temperature_path, 25.0)
+
+    print("\nUpdating pressure to 1.2")
+    data_model.write_variable(pressure_path, 1.2)
+
+
+if __name__ == "__main__":
+    main()

--- a/machine_data_model/behavior/execution_context.py
+++ b/machine_data_model/behavior/execution_context.py
@@ -9,6 +9,10 @@ from enum import IntEnum
 import re
 from typing import Any
 
+from machine_data_model.nodes.subscription.variable_subscription import (
+    SubscriptionCallback,
+)
+
 template_re = re.compile(r"\$\{([^}]+)\}")
 
 
@@ -165,6 +169,7 @@ class ExecutionContext:
     _pc: int
     _status: ControlFlowStatus
     active_request: str | None
+    _subscription_callback: SubscriptionCallback | None
 
     def __init__(self, context_id: str, **kwargs: dict[str, Any]):
         """Initialize a new ExecutionContext instance.
@@ -181,6 +186,7 @@ class ExecutionContext:
         self._pc = 0  # program counter
         self._status = ControlFlowStatus.READY
         self.active_request: str | None = None
+        self._subscription_callback = None
         self.set_all_values(**kwargs)
 
     def set_all_values(self, **kwargs: dict[str, Any]) -> None:
@@ -259,6 +265,33 @@ class ExecutionContext:
         var_name = resolve_string_in_context(var_name, self)
         if var_name in self._locals:
             del self._locals[var_name]
+
+    def set_subscription_callback(
+        self,
+        callback: SubscriptionCallback | None,
+    ) -> None:
+        """Set the callback used by scoped subscriptions in this context.
+
+        Args:
+            callback (SubscriptionCallback | None):
+                The callback to attach to subscriptions created during this
+                execution context. Set to None to clear the scoped callback.
+
+        """
+        self._subscription_callback = callback
+
+    def get_subscription_callback(
+        self,
+    ) -> SubscriptionCallback | None:
+        """Get the callback used by scoped subscriptions in this context.
+
+        Returns:
+            SubscriptionCallback | None:
+                The callback attached to subscriptions created during this
+                execution context, if any.
+
+        """
+        return self._subscription_callback
 
     def get_pc(self) -> int:
         """Get the program counter of the context.

--- a/machine_data_model/behavior/local_execution_node.py
+++ b/machine_data_model/behavior/local_execution_node.py
@@ -720,13 +720,23 @@ class WaitConditionNode(LocalExecutionNode):
         except KeyError:
             subscription = None
 
+        subscription_callback = context.get_subscription_callback()
+
         if subscription is None:
             # Create a new subscription for this context. Leave correlation_id
             # unspecified so the VariableSubscription constructor generates a
             # unique id for the subscription (previous behavior).
-            subscription = VariableSubscription(subscriber_id=context.id())
+            subscription = VariableSubscription(
+                subscriber_id=context.id(),
+                subscription_callback=subscription_callback,
+            )
             # store the subscription in the context for later retrieval
             context.set_value(sub_key, subscription)
+        elif (
+            subscription_callback is not None
+            and subscription.subscription_callback is None
+        ):
+            subscription.subscription_callback = subscription_callback
 
         # Condition not met - start waiting
         if not result:

--- a/machine_data_model/nodes/composite_method/composite_method_node.py
+++ b/machine_data_model/nodes/composite_method/composite_method_node.py
@@ -21,6 +21,9 @@ from machine_data_model.nodes.method_node import (
     MethodExecutionResult,
     MethodNode,
 )
+from machine_data_model.nodes.subscription.variable_subscription import (
+    SubscriptionCallback,
+)
 from machine_data_model.nodes.variable_node import VariableNode
 from machine_data_model.protocols.frost_v1.frost_message import FrostMessage
 from machine_data_model.protocols.frost_v1.frost_message_builder import (
@@ -193,6 +196,24 @@ class CompositeMethodNode(MethodNode):
         del self._contexts[context_id]
         self._completed_results.pop(context_id, None)
         self._notified_parent_contexts.discard(context_id)
+
+    def set_context_subscription_callback(
+        self,
+        context_id: str,
+        callback: SubscriptionCallback | None,
+    ) -> None:
+        """Set a scoped subscription callback for an active execution.
+
+        Args:
+            context_id (str):
+                The identifier of the execution context.
+            callback (SubscriptionCallback | None):
+                The callback to attach to subscriptions created in that
+                execution scope. Set to None to clear the scoped callback.
+
+        """
+        context = self._get_context(context_id)
+        context.set_subscription_callback(callback)
 
     def _notify_nested_parent(self, context: ExecutionContext) -> list[Any]:
         """Notify the parent composite method when this child finishes.

--- a/machine_data_model/nodes/subscription/variable_subscription.py
+++ b/machine_data_model/nodes/subscription/variable_subscription.py
@@ -16,6 +16,11 @@ if TYPE_CHECKING:
     from machine_data_model.nodes.variable_node import VariableNode
 
 
+SubscriptionCallback = Callable[
+    ["VariableSubscription", "VariableNode", Any], None
+]
+
+
 class EventType(IntFlag):
     """Enumeration of possible event types for variable subscriptions.
 
@@ -58,10 +63,7 @@ class VariableSubscription:
         self,
         subscriber_id: str,
         correlation_id: str = str(uuid4()),
-        subscription_callback: Callable[
-            ["VariableSubscription", "VariableNode", Any], None
-        ]
-        | None = None,
+        subscription_callback: SubscriptionCallback | None = None,
     ):
         self.subscriber_id = subscriber_id
         self.correlation_id = correlation_id

--- a/machine_data_model/protocols/frost_v1/frost_protocol_mng.py
+++ b/machine_data_model/protocols/frost_v1/frost_protocol_mng.py
@@ -384,6 +384,9 @@ class FrostProtocolMng(ProtocolMng):
             context_id = ret_values["@context_id"]
             assert isinstance(context_id, str)
             assert isinstance(method_node, CompositeMethodNode)
+            method_node.set_context_subscription_callback(
+                context_id, self._update_variable_callback
+            )
             self._running_methods[context_id] = (method_node, msg)
             # here we should return the accepted message
 
@@ -540,7 +543,9 @@ class FrostProtocolMng(ProtocolMng):
         assert isinstance(msg.payload, VariablePayload)
 
         subscription = VariableSubscription(
-            subscriber_id=msg.sender, correlation_id=msg.correlation_id
+            subscriber_id=msg.sender,
+            correlation_id=msg.correlation_id,
+            subscription_callback=self._update_variable_callback,
         )
         variable_node.subscribe(subscription)
         response = (

--- a/tests/behavior/test_local_execution_node.py
+++ b/tests/behavior/test_local_execution_node.py
@@ -22,6 +22,9 @@ from machine_data_model.nodes.composite_method.composite_method_node import (
 )
 from machine_data_model.nodes.folder_node import FolderNode
 from machine_data_model.nodes.method_node import AsyncMethodNode, MethodNode
+from machine_data_model.nodes.subscription.variable_subscription import (
+    VariableSubscription,
+)
 from machine_data_model.nodes.variable_node import (
     NumericalVariableNode,
     StringVariableNode,
@@ -135,6 +138,42 @@ class TestLocalExecutionNode:
         assert w_variable_node.node == variable_node.qualified_name
         assert ret.success == comparison_result
         assert len(ret.messages) == 0
+
+    def test_wait_condition_uses_context_subscription_callback(
+        self,
+    ) -> None:
+        context = ExecutionContext(str(uuid.uuid4()))
+        callbacks: list[tuple[str, Any]] = []
+
+        def subscription_callback(
+            subscription: VariableSubscription,
+            node: VariableNode,
+            value: Any,
+        ) -> None:
+            callbacks.append((subscription.subscriber_id, value))
+
+        context.set_subscription_callback(subscription_callback)
+
+        variable_node = get_random_numerical_node()
+        wait_node = WaitConditionNode(
+            variable_node=variable_node.qualified_name,
+            rhs=variable_node.read() + 1,
+            op=WaitConditionOperator.GE,
+        )
+        wait_node.set_ref_node(variable_node)
+
+        result = wait_node.execute(context)
+
+        assert not result.success
+        assert variable_node.has_subscribers()
+
+        subscription = variable_node.get_subscriptions()[0]
+        assert subscription.subscription_callback is subscription_callback
+
+        variable_node.write(variable_node.read() + 1)
+
+        assert callbacks
+        assert callbacks[0][0] == context.id()
 
     def test_nested_composite_method_call(self) -> None:
         root = FolderNode(name="root", description="Root folder")


### PR DESCRIPTION
### What this PR does

Adds support for scoping subscription callbacks to the active execution context, so wait conditions and runtime subscriptions use the correct listener instead of sharing callback state across executions.

### Why

Previously, subscription callbacks were effectively global to the variable node, which made nested or concurrent executions brittle. The missing piece was keeping the callback tied to the active context that created the subscription.

### Main changes

- Added context-scoped callback storage on `ExecutionContext`.
- Threaded the active callback through wait-condition subscription setup.
- Updated composite method execution to carry the scoped callback into child subscriptions.
- Added a shared `SubscriptionCallback` type alias to avoid repeating the callback signature.
- Added/updated tests to cover scoped wait-subscription behavior.
- Added a small subscription example showing multiple listeners and clear notification flow.

### Validation

- Focused behavior/composite test suites pass after the change.
- The subscription example runs and shows the expected callback sequence clearly.